### PR TITLE
Polish project template and fix a bug in dialog

### DIFF
--- a/source/Lens/CMakeLists.txt
+++ b/source/Lens/CMakeLists.txt
@@ -31,9 +31,9 @@ add_custom_command(
     COMMAND ${CMAKE_COMMAND} -E make_directory ${DESTINATION_DIR}
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
         ${CMAKE_CURRENT_SOURCE_DIR}/OutputFiles/imgui.ini
-        ${DESTINATION_DIR}/imgui.ini
+        ${DESTINATION_DIR}/project/imgui.ini
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
         ${CMAKE_CURRENT_SOURCE_DIR}/OutputFiles/template
-        ${DESTINATION_DIR}/template
+        ${DESTINATION_DIR}/project/template
     COMMENT "Copying resource files to output directory"
 )

--- a/source/Lens/RL_Projects.cpp
+++ b/source/Lens/RL_Projects.cpp
@@ -262,10 +262,11 @@ void RL_Projects::Save() const
 bool RL_Projects::GenerateProject(const char* _name, const char* _path)
 {
     uint32_t _template = 0;
+    std::string _templateDir(TEMPLATE_PATH);
     std::string _buffer;
     {
         // Todo, sometimes the template is not found
-        std::string _tempate_str = RE::FileSystem::Read(PROJECT_CONFIG_TEMPLATE);
+        std::string _tempate_str = RE::FileSystem::Read((_templateDir + PROJECT_CONFIG_TEMPLATE).c_str());
         if (_tempate_str.empty())
             return false;
         _template = RE::JSON::Parse(_tempate_str);
@@ -292,7 +293,7 @@ bool RL_Projects::GenerateProject(const char* _name, const char* _path)
     path += '\\';
     RE::FileSystem::WriteOutside(path.c_str(), name.c_str(), _buffer.c_str(), _buffer.size());
 
-    std::string _imgui = RE::FileSystem::Read(IMGUI_CONFIG_TEMPLATE);
+    std::string _imgui = RE::FileSystem::Read((_templateDir + IMGUI_CONFIG_TEMPLATE).c_str());
     if (_imgui.empty())
         return false;
     RE::FileSystem::WriteOutside(path.c_str(), IMGUI_CONFIG_TEMPLATE, _imgui.c_str(), _imgui.size());

--- a/source/Lens/RL_Projects.h
+++ b/source/Lens/RL_Projects.h
@@ -53,13 +53,10 @@ class RL_Projects
 
   private:
     static constexpr const char* PROJECTS_FILE = "WriteDir/Projects.json";
+    static constexpr const char* TEMPLATE_PATH = "project/";
     static constexpr const char* PROJECT_CONFIG_TEMPLATE = "template";
     static constexpr const char* IMGUI_CONFIG_TEMPLATE = "imgui.ini";
-#ifdef _DEBUG
-    static constexpr const char* ENGINE_EXECUTABLE = "Engine-d.exe";
-#else
     static constexpr const char* ENGINE_EXECUTABLE = "Engine.exe";
-#endif
     std::vector<Project> _projects;
 };
 

--- a/source/Modules/RE_Dialogs.ixx
+++ b/source/Modules/RE_Dialogs.ixx
@@ -33,6 +33,11 @@ export module Dialogs;
  */
 std::string WCharToString(const wchar_t* wstr)
 {
+    if (wstr == nullptr)
+    {
+        return "";
+    }
+
     std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
     return converter.to_bytes(wstr);
 }
@@ -44,6 +49,11 @@ std::string WCharToString(const wchar_t* wstr)
  */
 std::wstring CharToWChar(const char* str)
 {
+    if (str == nullptr)
+    {
+        return L"";
+    }
+
     std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
     return converter.from_bytes(str);
 }


### PR DESCRIPTION
This pull request includes several changes to improve file handling, template management, and error handling in the project. The most important changes include updating paths for resource files, adding a new template path constant, and improving string conversion functions to handle null pointers.

### File Handling and Template Management:

* [`source/Lens/CMakeLists.txt`](diffhunk://#diff-e8f2db2c5040e9a99b14a5c509446ef18112a3914818161a1ac63ae9c5cbe744L34-R37): Updated the destination paths for `imgui.ini` and `template` files to include the `project` subdirectory.
* [`source/Lens/RL_Projects.cpp`](diffhunk://#diff-5cb53bdb043f5b1fee1bc5857b82edf0f8e67d531ed7f58470a066a01f8e6a91R265-R269): Modified the `GenerateProject` function to prepend `TEMPLATE_PATH` to the `PROJECT_CONFIG_TEMPLATE` and `IMGUI_CONFIG_TEMPLATE` paths when reading template files. [[1]](diffhunk://#diff-5cb53bdb043f5b1fee1bc5857b82edf0f8e67d531ed7f58470a066a01f8e6a91R265-R269) [[2]](diffhunk://#diff-5cb53bdb043f5b1fee1bc5857b82edf0f8e67d531ed7f58470a066a01f8e6a91L295-R296)
* [`source/Lens/RL_Projects.h`](diffhunk://#diff-eb2f3f2b8dc3988262dc3df43df64a515dc8fc03d205c43cdc5df3996b281370R56-L62): Added `TEMPLATE_PATH` constant to define the base directory for template files.

### Error Handling:

* [`source/Modules/RE_Dialogs.ixx`](diffhunk://#diff-7e03329d1e259a42414f5c66c126927ac28768955d9aaf1036cc374fdf611aa5R36-R40): Enhanced `WCharToString` and `CharToWChar` functions to return empty strings when the input is a null pointer. [[1]](diffhunk://#diff-7e03329d1e259a42414f5c66c126927ac28768955d9aaf1036cc374fdf611aa5R36-R40) [[2]](diffhunk://#diff-7e03329d1e259a42414f5c66c126927ac28768955d9aaf1036cc374fdf611aa5R52-R56)