### PR TITLE
Gtest implementation

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -117,6 +117,15 @@ jobs:
     - name: Build Debug
       # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       run: cmake --build ${{ steps.strings.outputs.build-output-dir }}/${{ matrix.platform }}-debug-${{ matrix.beauty_os }}
+    
+    - name: Test Debug
+      working-directory: ${{ steps.strings.outputs.build-output-dir }}
+      # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: |
+        cd ${{ steps.strings.outputs.build-output-dir }}/${{ matrix.platform }}-debug-${{ matrix.beauty_os }}
+        ctest --verbose
+        cd ${{ github.workspace }}
 
     - name: Configure CMake Release
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
@@ -127,8 +136,11 @@ jobs:
       # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       run: cmake --build ${{ steps.strings.outputs.build-output-dir }}/${{ matrix.platform }}-release-${{ matrix.beauty_os }}
     
-    - name: Test
+    - name: Test Release
       working-directory: ${{ steps.strings.outputs.build-output-dir }}
       # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest ${{ steps.strings.outputs.build-output-dir }}/${{ matrix.platform }}-release-${{ matrix.beauty_os }} --verbose
+      run: |
+        cd ${{ steps.strings.outputs.build-output-dir }}/${{ matrix.platform }}-release-${{ matrix.beauty_os }}
+        ctest --verbose
+        cd ${{ github.workspace }}

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -127,8 +127,8 @@ jobs:
       # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       run: cmake --build ${{ steps.strings.outputs.build-output-dir }}/${{ matrix.platform }}-release-${{ matrix.beauty_os }}
     
-    # - name: Test
-    #   working-directory: ${{ steps.strings.outputs.build-output-dir }}
-    #   # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
-    #   # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-    #   run: ctest --build-config ${{ matrix.build_type }}
+    - name: Test
+      working-directory: ${{ steps.strings.outputs.build-output-dir }}
+      # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest ${{ steps.strings.outputs.build-output-dir }}/${{ matrix.platform }}-release-${{ matrix.beauty_os }} --verbose

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,3 +11,6 @@ set(CMAKE_CXX_SCAN_FOR_MODULES ON)
 
 project ("RedEye")
 add_subdirectory(source)
+
+enable_testing()
+add_subdirectory(tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,2 @@
+find_package(GTest CONFIG REQUIRED)
+add_subdirectory(json)

--- a/tests/json/CMakeLists.txt
+++ b/tests/json/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_executable(
+  json_test
+  json_test.cpp
+)
+
+target_link_libraries(json_test PRIVATE
+  RedEye_lib
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock
+  GTest::gmock_main
+)
+
+add_test(json json_test)

--- a/tests/json/json_test.cpp
+++ b/tests/json/json_test.cpp
@@ -1,0 +1,50 @@
+#include <gtest/gtest.h>
+import JSON;
+
+TEST(JsonTest, CreateJsonContainer)
+{
+    uint32_t id = RE::JSON::Create();
+    ASSERT_NE(id, 0);
+    RE::JSON::Destroy(id);
+}
+
+TEST(JsonTest, ParseJsonString)
+{
+    const std::string jsonString = R"({"name":"RedEye","version":1})";
+    uint32_t id = RE::JSON::Parse(jsonString);
+    ASSERT_NE(id, 0);
+
+    std::string buffer = RE::JSON::GetBuffer(id);
+    ASSERT_EQ(buffer, jsonString);
+    RE::JSON::Destroy(id);
+}
+
+TEST(JsonTest, GetJsonValue)
+{
+    const std::string jsonString = R"({"name":"RedEye","version":1})";
+    uint32_t id = RE::JSON::Parse(jsonString);
+    ASSERT_NE(id, 0);
+
+    std::string name = RE::JSON::Value::PullString("name", "", id);
+    ASSERT_EQ(name, "RedEye");
+    RE::JSON::Destroy(id);
+}
+
+TEST(JsonTest, SetJsonValue)
+{
+    uint32_t id = RE::JSON::Create();
+    ASSERT_NE(id, 0);
+
+    RE::JSON::Value::PushString("RedEye", "name", id);
+
+    std::string name = RE::JSON::Value::PullString("name", "", id);
+    ASSERT_EQ(name, "RedEye");
+
+    RE::JSON::Destroy(id);
+}
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -11,6 +11,7 @@
     "nativefiledialog-extended",
     "physfs",
     "rapidjson",
-    "sdl2"
+    "sdl2",
+    "gtest"
   ]
 }


### PR DESCRIPTION
This pull request introduces several changes to the build and testing configuration of the project, specifically adding support for Google Test (GTest) and enabling testing. The most important changes include modifications to the CMake configuration files, the addition of a new test executable, and the inclusion of GTest in the project dependencies.

### Build and Testing Configuration:

* [`.github/workflows/cmake-multi-platform.yml`](diffhunk://#diff-e140c2f8e760152e341a3449a5d4c370af357beeb2ad3f163b7ed9e774769c54L130-R134): Re-enabled and updated the test step to execute tests with verbose output.
* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR14-R16): Enabled testing and added the `tests` subdirectory to the build configuration.
* [`tests/CMakeLists.txt`](diffhunk://#diff-4461c617ceae0c7e0206622aacdf555aedd62eb129c2efb74c84fa1567bcbe0dR1-R2): Added configuration to find and use GTest, and included the `json` subdirectory.

### Test Executable:

* [`tests/json/CMakeLists.txt`](diffhunk://#diff-e66391e505f5ba980d6ccdf7274a8208d718a2d2a6d14d44396c0c6c39070c7fR1-R14): Created a new test executable `json_test` and linked it with `RedEye_lib` and GTest libraries.
* [`tests/json/json_test.cpp`](diffhunk://#diff-ef53e236c74fd39dbb412f628e890240fb57c5cb367e358ea1a17ea33f78443fR1-R50): Added unit tests for JSON creation, parsing, value retrieval, and value setting using GTest framework.

### Project Dependencies:

* [`vcpkg.json`](diffhunk://#diff-dbbb1b147126744a5eee012901d2b9a29cc478be03677f67825b9b2794f5d283L14-R15): Added GTest to the list of project dependencies.