### PR TITLE
Update SDL3 integration

### DIFF
--- a/source/Lens/RL_Application.cpp
+++ b/source/Lens/RL_Application.cpp
@@ -23,7 +23,7 @@
 
 #include "RL_Projects.h"
 
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include <functional>
 
 import FileSystem;

--- a/source/Lens/RL_Application.h
+++ b/source/Lens/RL_Application.h
@@ -19,6 +19,8 @@
 #ifndef JR_APPLICATION_CLASS
 #define JR_APPLICATION_CLASS
 
+#include <SDL3/SDL.h>
+
 class JR_Application
 {
   public:

--- a/source/Lens/RL_Input.cpp
+++ b/source/Lens/RL_Input.cpp
@@ -19,7 +19,7 @@
 #include "RL_Input.h"
 
 #include <functional>
-#include <imgui_impl_sdl2.h>
+#include <imgui_impl_sdl3.h>
 
 import EventSystem;
 
@@ -32,5 +32,5 @@ bool JR_Input::Init()
 
 void JR_Input::EventListener(SDL_Event* event)
 {
-    ImGui_ImplSDL2_ProcessEvent(event);
+    ImGui_ImplSDL3_ProcessEvent(event);
 }

--- a/source/Lens/RL_Input.h
+++ b/source/Lens/RL_Input.h
@@ -19,6 +19,8 @@
 #ifndef JR_INPUT_CLASS
 #define JR_INPUT_CLASS
 
+#include <SDL3/SDL.h>
+
 class JR_Input
 {
   public:

--- a/source/Lens/RL_WindowAndRenderer.cpp
+++ b/source/Lens/RL_WindowAndRenderer.cpp
@@ -20,10 +20,10 @@
 
 #include "RL_Application.h"
 
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include <imgui_impl_opengl3.h>
 #include <imgui_impl_opengl3_loader.h>
-#include <imgui_impl_sdl2.h>
+#include <imgui_impl_sdl3.h>
 #include <functional>
 
 import EventSystem;
@@ -62,7 +62,7 @@ bool JR_WindowAndRenderer::Init()
 void JR_WindowAndRenderer::PostUpdate()
 {
     ImGui_ImplOpenGL3_NewFrame();
-    ImGui_ImplSDL2_NewFrame();
+    ImGui_ImplSDL3_NewFrame();
     ImGui::NewFrame();
 
     RE::GUI::Draw();
@@ -91,7 +91,7 @@ void JR_WindowAndRenderer::PostUpdate()
 
 void JR_WindowAndRenderer::CleanUp()
 {
-    SDL_GL_DeleteContext(context);
+    SDL_GL_DestroyContext(context);
 }
 
 SDL_Window* JR_WindowAndRenderer::GetMainWindow() const

--- a/source/Lens/RL_WindowAndRenderer.h
+++ b/source/Lens/RL_WindowAndRenderer.h
@@ -19,7 +19,8 @@
 #ifndef JR_WINDOWRENDERER_CLASS
 #define JR_WINDOWRENDERER_CLASS
 
-#include <SDL2/SDL_render.h>
+#include <SDL3/SDL_render.h>
+#include <SDL3/SDL.h>
 
 class JR_WindowAndRenderer
 {

--- a/source/Lens/main.cpp
+++ b/source/Lens/main.cpp
@@ -17,7 +17,7 @@
  */
 
 #include "RL_Application.h"
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 
 int main(int argc, char* argv[])
 {

--- a/source/Modules/RE_GUIManager.ixx
+++ b/source/Modules/RE_GUIManager.ixx
@@ -19,8 +19,10 @@
 module;
 
 #include <functional>
+#include <SDL3/SDL.h>
 #include <imgui_impl_opengl3.h>
 #include <imgui_impl_opengl3_loader.h>
+#include <imgui_impl_sdl3.h>
 #include <imgui_internal.h>
 
 export module GUIManager;
@@ -159,7 +161,7 @@ export namespace RE
             }
 
             // Setup Platform/Renderer backends
-            if (ImGui_ImplSDL2_InitForOpenGL(_window, _sdl_gl_context))
+            if (ImGui_ImplSDL3_InitForOpenGL(_window, _sdl_gl_context))
             {
                 if (ImGui_ImplOpenGL3_Init("#version 130"))
                 {
@@ -243,7 +245,7 @@ export namespace RE
         void CleanUp()
         {
             ImGui_ImplOpenGL3_Shutdown();
-            ImGui_ImplSDL2_Shutdown();
+            ImGui_ImplSDL3_Shutdown();
             ImGui::DestroyContext();
         }
     } // namespace GUI

--- a/source/Modules/RE_WindowManager.ixx
+++ b/source/Modules/RE_WindowManager.ixx
@@ -43,7 +43,7 @@ export namespace RE
          * @param w The width of the window (default is 500).
          * @param h The height of the window (default is 500).
          * @param flags The window flags (default is SDL_WINDOW_OPENGL |
-         * SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_SHOWN).
+         * SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIGH_PIXEL_DENSITY).
          * @return The ID of the newly created window.
          */
         uint32_t NewWindow(const char* title, int x = SDL_WINDOWPOS_CENTERED, int y = SDL_WINDOWPOS_CENTERED,

--- a/source/Modules/Render/RenderAPIHandler.ixx
+++ b/source/Modules/Render/RenderAPIHandler.ixx
@@ -194,7 +194,7 @@ export namespace RE
         {
             const uint32_t OpenGL = SDL_WINDOW_OPENGL;
             const uint32_t Vulkan = SDL_WINDOW_VULKAN;
-            const uint32_t DEFAULT = SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_SHOWN;
+            const uint32_t DEFAULT = SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIGH_PIXEL_DENSITY | SDL_WINDOW_SHOWN;
         } // namespace Flag
 
         bool Init()


### PR DESCRIPTION
## Summary
- switch GUIManager to SDL3
- include SDL headers in Lens module headers

## Testing
- `git submodule update --init --recursive`
- `cmake --preset x64-debug-linux` *(fails: vcpkg install glew BUILD_FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_68438af1905c8321a3459b1c7722f075